### PR TITLE
Modify the bug: If there is not cpu freq information return nothing

### DIFF
--- a/widgets/cpufreq.lua
+++ b/widgets/cpufreq.lua
@@ -29,13 +29,20 @@ local function worker(format, warg)
     }
     -- Default voltage values
     local voltage = { v  = "N/A", mv = "N/A" }
+    local freqmhz = "N/A"
+    local freqghz = "N/A"
 
 
     -- Get the current frequency
     local freq = tonumber(cpufreq.scaling_cur_freq)
     -- Calculate MHz and GHz
-    local freqmhz = freq / 1000
-    local freqghz = freqmhz / 1000
+
+    if freq then
+        freqmhz = freq / 1000
+        freqghz = freqmhz / 1000
+    end
+
+
 
     -- Get the current voltage
     if cpufreq.scaling_voltages then
@@ -48,6 +55,8 @@ local function worker(format, warg)
     local governor = cpufreq.scaling_governor
     -- Represent the governor as a symbol
     governor = governor_state[governor] or governor
+
+    if governor == nil then governor = "N/A" end
 
     return {freqmhz, freqghz, voltage.mv, voltage.v, governor}
 end


### PR DESCRIPTION
Such as my VirtualBox not cpu0/cpufreq information. the lua returns nil. 

Show $1 such as that.

This will fix the bug. changed the text "$1" to "N/A"
