### PR TITLE
Escape XML entities by default

### DIFF
--- a/contrib/cmus_all.lua
+++ b/contrib/cmus_all.lua
@@ -44,12 +44,10 @@ local function worker(format, warg)
 
     for line in f:lines() do
         for module, value in string.gmatch(line, "([%w]+) (.*)$") do
-            if module == "file" then
-                cmus_state["{"..module.."}"] = helpers.escape(value)
+            if module == "file"  or module == "status" then
+                cmus_state["{"..module.."}"] = value
             elseif module == "duration" then
                 cmus_state["{"..module.."}"] = tonumber(value)
-            elseif module == "status" then
-                cmus_state["{"..module.."}"] = value
             else
                 for k, v in string.gmatch(value, "([%w]+) (.*)$") do
                     if module == "tag" then

--- a/contrib/mpc_all.lua
+++ b/contrib/mpc_all.lua
@@ -41,7 +41,7 @@ local function worker(format, warg)
         end
     end
 
-    return {helpers.escape(np)}
+    return {np}
 end
 -- }}}
 

--- a/init.lua
+++ b/init.lua
@@ -52,10 +52,19 @@ local function update(widget, reg, disablecache)
     local function format_data(data)
         local ret
         if type(data) == "table" then
+            local escaped_data = {}
+            for k, v in pairs(data) do
+                if type(v) == "string" then
+                    escaped_data[k] = helpers.escape(v)
+                else
+                    escaped_data[k] = v
+                end
+            end
+
             if type(reg.format) == "string" then
-                ret = helpers.format(reg.format, data)
+                ret = helpers.format(reg.format, escaped_data)
             elseif type(reg.format) == "function" then
-                ret = reg.format(widget, data)
+                ret = reg.format(widget, escaped_data)
             end
         end
         return ret or data

--- a/widgets/gmail_all.lua
+++ b/widgets/gmail_all.lua
@@ -65,7 +65,7 @@ local function worker(format, warg)
         end
 
         -- Spam sanitize the subject and store
-        mail["{subject}"] = helpers.escape(title)
+        mail["{subject}"] = title
     end
 
     f:close()

--- a/widgets/mbox_all.lua
+++ b/widgets/mbox_all.lua
@@ -46,7 +46,7 @@ local function worker(format, warg)
         end
     end
 
-    return {helpers.escape(subject)}
+    return {subject}
 end
 -- }}}
 

--- a/widgets/mpd_all.lua
+++ b/widgets/mpd_all.lua
@@ -44,14 +44,15 @@ local function worker(format, warg)
 
     for line in f:lines() do
         for k, v in string.gmatch(line, "([%w]+):[%s](.*)$") do
-            if     k == "volume" then mpd_state["{"..k.."}"] = v and tonumber(v)
-            elseif k == "state"  then mpd_state["{"..k.."}"] = helpers.capitalize(v)
-            elseif k == "Artist" then mpd_state["{"..k.."}"] = helpers.escape(v)
-            elseif k == "Title"  then mpd_state["{"..k.."}"] = helpers.escape(v)
-            elseif k == "Album"  then mpd_state["{"..k.."}"] = helpers.escape(v)
-            elseif k == "Genre"  then mpd_state["{"..k.."}"] = helpers.escape(v)
-            --elseif k == "Name" then mpd_state["{"..k.."}"] = helpers.escape(v)
-            --elseif k == "file" then mpd_state["{"..k.."}"] = helpers.escape(v)
+            local key = "{" .. k .. "}"
+            if k == "volume" then
+                mpd_state[key] = v and tonumber(v)
+            elseif k == "state" then
+                mpd_state[key] = helpers.capitalize(v)
+            elseif k == "Artist" or k == "Title"  or
+                   --k == "Name" or k == "file" or
+                   k == "Album" or k == "Genre" then
+                mpd_state[key] = v
             end
         end
     end

--- a/widgets/wifi_linux.lua
+++ b/widgets/wifi_linux.lua
@@ -69,8 +69,8 @@ local function worker(format, warg)
 
     -- Output differs from system to system, some stats can be
     -- separated by =, and not all drivers report all stats
-    winfo["{ssid}"] =  -- SSID can have almost anything in it
-      helpers.escape(string.match(iw, 'ESSID[=:]"(.-)"') or winfo["{ssid}"])
+    -- SSID can have almost anything in it
+    winfo["{ssid}"] = string.match(iw, 'ESSID[=:]"(.-)"') or winfo["{ssid}"]
     winfo["{mode}"] =  -- Modes are simple, but also match the "-" in Ad-Hoc
       string.match(iw, "Mode[=:]([%w%-]*)") or winfo["{mode}"]
     winfo["{chan}"] =  -- Channels are plain digits


### PR DESCRIPTION
Since most Awesome widgets provide set_widget method, texts are likely to be parsed to Pango which consume these entities and may fail on invalid ones.

On my [master](https://github.com/McSinyx/vicious) I'm also reformatting the README, hope I'm going on the right direction.