### PR TITLE
contrib: Add hwmontemp_linux

### DIFF
--- a/contrib/README.md
+++ b/contrib/README.md
@@ -105,6 +105,20 @@ Provides I/O statistics for requested storage devices.
   `${read_s}`, `${read_kb}`, `${read_mb}`, `${write_s}`, `${write_kb}`,
   `${write_mb}` and `${sched}`
 
+### vicious.contrib.hwmontemp
+
+Provides name-based access to hwmon devices via sysfs.
+
+* Argument: table with sensor name and (optional) input number, e.g.
+  `{ "radeon", 2 }` (input no. is assumed to be 1 if omitted)
+* Returns a table with just the temperature value: `$1`
+* Usage example:
+
+```lua
+gputemp = wibox.widget.textbox()
+vicious.register(gputemp, vicious.contrib.hwmontemp, " $1°C", 5, { "radeon" })
+```
+
 ### vicious.contrib.mpc
 
 ### vicious.contrib.netcfg

--- a/contrib/hwmontemp_linux.lua
+++ b/contrib/hwmontemp_linux.lua
@@ -1,0 +1,61 @@
+----------------------------------------------------------------
+--   Licensed under the GNU General Public License v2
+--   (C) 2019, Alexander Koch <lynix47@gmail.com>
+----------------------------------------------------------------
+
+-- environment
+local io = { popen = io.popen, open = io.open }
+local setmetatable = setmetatable
+
+-- sysfs prefix for hwmon devices
+local sys_hwmon = "/sys/class/hwmon"
+-- cache table for hwmon device names
+local paths = {}
+
+-- transparently caching hwmon device name lookup
+function name_to_path(name)
+    if paths[name] then return paths[name] end
+
+    for sensor in io.popen("ls -1 " .. sys_hwmon):lines() do
+        local path = sys_hwmon .. "/" .. sensor
+        local f = assert(io.open(path .. "/name", "r"))
+        local sname = f:read("*line")
+        f:close()
+        if sname == name then
+            paths[name] = path
+            return path
+        end
+    end
+
+    return nil
+end
+
+-- hwmontemp: provides name-indexed temps from /sys/class/hwmon
+-- vicious.contrib.hwmontemp
+local hwmontemp_linux = {}
+
+function worker(format, warg)
+    if not warg[1] then
+        return { "E" }
+    end
+    name = warg[1]
+
+    if not warg[2] then
+        input = 1
+    else
+        input = warg[2]
+    end
+
+    local sensor = name_to_path(name)
+    if not sensor then return { "n/a" } end
+
+    local f = assert(io.open(sensor .. "/temp" .. input .. "_input", "r"))
+    local temp = f:read("*line")
+    f:close()
+
+    return { temp / 1000 }
+end
+
+return setmetatable(hwmontemp_linux, { __call = function(_, ...) return worker(...) end })
+
+-- vim: ts=4:sw=4:expandtab


### PR DESCRIPTION
I'd like to introduce a new widget _hwmontemp_, which provides name-based access to hwmon
temperature sensors via sysfs.

Motivation for creating this widget was the fact that all existing hwmon widgets seem to require the sysfs path to be static. This is not the case for my system, i.e. hwmon device numbers below _/sys/class/hwmon_ are determined by module load order and vary between system boots.

This widget aims at solving this problem by making hwmon sensors accessible by name instead of sysfs path. In order to avoid unnecessary sysfs traversal for subsequent queries the name -> path mapping is cached.