### PR TITLE
widgets: Add hwmontemp_linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,6 +259,22 @@ Supported platforms: GNU/Linux, requiring `hddtemp` and `curl`.
 * Returns a table with string keys, using hard drives as a base, e.g.
   `${/dev/sda}` and `${/dev/sdc}`.
 
+### vicious.widgets.hwmontemp
+
+Provides name-based access to hwmon devices via sysfs.
+
+Supported platforms: GNU/Linux
+
+* Argument: table with sensor name and (optional) input number, e.g.
+  `{ "radeon", 2 }` (input no. is assumed to be 1 if omitted)
+* Returns a table with just the temperature value: `$1`
+* Usage example:
+
+```lua
+gputemp = wibox.widget.textbox()
+vicious.register(gputemp, vicious.contrib.hwmontemp, " $1°C", 5, { "radeon" })
+```
+
 ### vicious.widgets.mbox
 
 Provides the subject of last e-mail in a mbox file.

--- a/widgets/hwmontemp_linux.lua
+++ b/widgets/hwmontemp_linux.lua
@@ -1,0 +1,60 @@
+----------------------------------------------------------------
+--   Licensed under the GNU General Public License v2
+--   (C) 2019, Alexander Koch <lynix47@gmail.com>
+----------------------------------------------------------------
+
+-- environment
+local io = { popen = io.popen, open = io.open }
+local assert = assert
+local setmetatable = setmetatable
+
+-- sysfs prefix for hwmon devices
+local sys_hwmon = "/sys/class/hwmon/"
+-- cache table for hwmon device names
+local paths = {}
+
+-- transparently caching hwmon device name lookup
+function name_to_path(name)
+    if paths[name] then return paths[name] end
+
+    for sensor in io.popen("ls -1 " .. sys_hwmon):lines() do
+        local path = sys_hwmon .. sensor
+        local f = assert(io.open(path .. "/name", "r"))
+        local sname = f:read("*line")
+        f:close()
+        if sname == name then
+            paths[name] = path
+            return path
+        end
+    end
+
+    return nil
+end
+
+-- hwmontemp: provides name-indexed temps from /sys/class/hwmon
+-- vicious.widgets.hwmontemp
+local hwmontemp_linux = {}
+
+function worker(format, warg)
+    assert(type(warg) == "table", "invalid hwmontemp argument: must be a table")
+    name = warg[1]
+
+    if not warg[2] then
+        input = 1
+    else
+        input = warg[2]
+    end
+
+    local sensor = name_to_path(name)
+    if not sensor then return { "N/A" } end
+
+    local f = assert(io.open(("%s/temp%d_input"):format(sensor, input), "r"))
+    local temp = f:read("*line")
+    f:close()
+
+    return { temp / 1000 }
+end
+
+return setmetatable(hwmontemp_linux, { __call = function(_, ...) return worker(...) end })
+
+-- vim: ts=4:sw=4:expandtab


### PR DESCRIPTION
Improved version of #68 with review comments taken into account.
- Switch from `contrib` to `widgets`
- Use `s:format()` instead of string concatenation for input file
- Adhere to `"N/A"` convention
- Use assertion for worker argument

Original pull description:

> I'd like to introduce a new widget hwmontemp, which provides name-based access to hwmon temperature sensors via sysfs.
> 
> Motivation for creating this widget was the fact that all existing hwmon widgets seem to require the sysfs path to be static. This is not the case for my system, i.e. hwmon device numbers below /sys/class/hwmon are determined by module load order and vary between system boots.
> 
> This widget aims at solving this problem by making hwmon sensors accessible by name instead of sysfs path. In order to avoid unnecessary sysfs traversal for subsequent queries the name -> path mapping is cached.