### PR TITLE
Fix luacheck issues and add .luacheckrc

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -1,0 +1,9 @@
+-- Only allow symbols available in all Lua versions
+std = "min"
+
+-- Global objects defined by the C code
+read_globals = {
+    "timer",  -- deprecated, but used in older versions.
+}
+
+-- vim: filetype=lua:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80


### PR DESCRIPTION
Uses `reg.timeout` for clarity (triggered via "shadowing upvalue timer
on line 13"), but keeps `reg.timer` for backward compatibility.