### PR TITLE
[mpd] Use math.floor when formatting song progress

### DIFF
--- a/widgets/mpd_all.lua
+++ b/widgets/mpd_all.lua
@@ -9,6 +9,7 @@ local io = { popen = io.popen }
 local setmetatable = setmetatable
 local string = { gmatch = string.gmatch }
 local helpers = require("vicious.helpers")
+local math = require("math")
 -- }}}
 
 
@@ -25,8 +26,8 @@ end
 
 -- {{{ Format playing progress
 function format_progress(elapsed, duration)
-    local em, es = elapsed / 60, elapsed % 60
-    local dm, ds = duration / 60, duration % 60
+    local em, es = math.floor(elapsed / 60), math.floor(elapsed % 60)
+    local dm, ds = math.floor(duration / 60), math.floor(duration % 60)
 
     if dm < 10 then
         return ("%d:%02d"):format(em, es), ("%d:%02d"):format(dm, ds)

--- a/widgets/mpd_all.lua
+++ b/widgets/mpd_all.lua
@@ -9,7 +9,7 @@ local io = { popen = io.popen }
 local setmetatable = setmetatable
 local string = { gmatch = string.gmatch }
 local helpers = require("vicious.helpers")
-local math = require("math")
+local math = { floor = math.floor }
 -- }}}
 
 


### PR DESCRIPTION
There was an error in the `format_progress` function in my environment.

```bash
me@localhost vicious> lua -v
Lua 5.3.5  Copyright (C) 1994-2018 Lua.org, PUC-Rio
me@localhost vicious> awesome -v
awesome v4.3-91-ga0731023 (Too long)
 • Compiled against Lua 5.3.5 (running with Lua 5.3)
 • D-Bus support: ✔
 • execinfo support: ✔
 • xcb-randr version: 1.6
 • LGI version: 0.9.2
```