### PR TITLE
Fix bat_openbsd compatibility with Lua 5.3 and remaining time display

### DIFF
--- a/widgets/bat_openbsd.lua
+++ b/widgets/bat_openbsd.lua
@@ -4,13 +4,8 @@ local tonumber = tonumber
 local string = { format = string.format, gmatch = string.gmatch }
 local io = { popen = io.popen }
 local math = { floor = math.floor }
-local helpers = require("vicious.helpers")
-local string = {
-    gmatch = string.gmatch,
-    match = string.match,
-    format = string.format
-}
 -- }}}
+
 local bat_openbsd = {}
 
 local function worker(format, warg)

--- a/widgets/bat_openbsd.lua
+++ b/widgets/bat_openbsd.lua
@@ -3,7 +3,7 @@ local setmetatable = setmetatable
 local tonumber = tonumber
 local string = { format = string.format, gmatch = string.gmatch }
 local io = { popen = io.popen }
-local math = { floor = math.floor }
+local math = { floor = math.floor, modf = math.modf }
 -- }}}
 
 local bat_openbsd = {}

--- a/widgets/bat_openbsd.lua
+++ b/widgets/bat_openbsd.lua
@@ -38,10 +38,10 @@ local function worker(format, warg)
     if tonumber(bat_info.power0) < 1 then
         time = "∞"
     else
-	local raw_time = bat_info.watthour3 / bat_info.power0
-	local hours = math.floor(raw_time)
-	local minutes = raw_time % 1
-	time = string.format("%d:%0.2d", hours, minutes)
+        local raw_time = bat_info.watthour3 / bat_info.power0
+        local hours, hour_fraction = math.modf(raw_time)
+        local minutes = math.floor(60 * hour_fraction)
+        time = string.format("%d:%0.2d", hours, minutes)
     end
 
     -- calculate wear level from (last full / design) capacity


### PR DESCRIPTION
This PR fixes compatibility with Lua 5.3. I didn't realise it would crash on this version because the OpenBSD Awesome port runs in 5.2. I should've checked beforehand, so let me apologise for not keeping compatibility. I've also changed the way I get hours and minutes from the sysctl output: I was using the `% 1` operation to get the fractional part of a number but I now grab both hours and minutes from `math.modf` instead.