### PR TITLE
Surface {when} in UTC for weather widget

### DIFF
--- a/README.md
+++ b/README.md
@@ -505,7 +505,7 @@ Supported platforms: any having Awesome and `curl` installed.
 * Argument: the ICAO station code, e.g. `"LDRI"`
 * Returns a table with string keys: `${city}`, `${wind}`, `${windmph}`,
   `${windkmh}`, `${sky}`, `${weather}`, `${tempf}`, `${tempc}`, `${humid}`,
-  `${dewf}`, `${dewc}` and `${press}`
+  `${dewf}`, `${dewc}` and `${press}`, `${when}`
 
 ### vicious.widgets.wifi
 


### PR DESCRIPTION
Here's how I use this:

```lua
   -- copied from http://lua-users.org/wiki/TimeZone
   local function get_timezone_offset()
       local ts = os.time()
       local utcdate   = os.date("!*t", ts)
       local localdate = os.date("*t", ts)
       localdate.isdst = false -- this is the trick
       return os.difftime(os.time(localdate), os.time(utcdate))
   end

   -- ...

   vicious.register(actual_widget, vicious.widgets.weather,
     function (widget, args)
       actual_tooltip:set_text(
         "City: " .. args["{city}"] ..
           "\nWind: " .. args["{windmph}"] .. "mph " ..
           "\nSky: " .. args["{sky}"] ..
           "\nHumidity: " .. args["{humid}"] ..
           "\nMeasured at: " .. os.date("%F %T", args["{when}"] + get_timezone_offset()))
```