### PR TITLE
Add a notmuch widget

### DIFF
--- a/README.md
+++ b/README.md
@@ -399,7 +399,9 @@ Provides a message count according to an arbitrary Notmuch query.
 
 Supported platforms: platform independent.
 
-Argument: the query that is passed to Notmuch. For instance: `tag:inbox AND tag:unread` returns the number of unread messages with tag "inbox". 
+Argument: the query that is passed to Notmuch. For instance:
+`tag:inbox AND tag:unread` returns the number of unread messages with
+tag "inbox".
 
 Returns a table with string keys containing:
 * `${count}`: the count of messages that match the query

--- a/README.md
+++ b/README.md
@@ -393,6 +393,18 @@ Supported platforms: GNU/Linux, FreeBSD.
     `${down_b}`, `${up_b}`, `${down_kb}`, `${up_kb}`, `${down_mb}`, `${up_mb}`,
     `${down_gb}`, `${up_gb}`.
 
+### vicious.widgets.notmuch
+
+Provides a message count according to an arbitrary Notmuch query.
+
+Supported platforms: platform independent.
+
+Argument: the query that is passed to Notmuch. For instance: `tag:inbox AND tag:unread` returns the number of unread messages with tag "inbox". 
+
+Returns a table with string keys containing:
+* `${count}`: the count of messages that match the query
+
+
 ### vicious.widgets.org
 
 Provides agenda statistics for Emacs org-mode.

--- a/widgets/notmuch_all.lua
+++ b/widgets/notmuch_all.lua
@@ -24,7 +24,7 @@ local spawn = require("vicious.spawn")
 local notmuch = {}
 
 local function parse(stdout, stderr, exitreason, exitcode)
-    local output = {count = "N/A"}
+    local output = { count = "N/A" }
     if exitcode == 0 then output.count = tonumber(stdout) end
     return output
 end
@@ -32,7 +32,7 @@ end
 function notmuch.async(format, warg, callback)
     local cmd = ("notmuch count '^%s'"):format(warg)
 
-    spawn.easy_async(cmd, function(...) callback(parse(...)) end)
+    spawn.easy_async(cmd, function (...) callback(parse(...)) end)
 end
 
 return helpers.setasyncall(notmuch)

--- a/widgets/notmuch_all.lua
+++ b/widgets/notmuch_all.lua
@@ -1,0 +1,42 @@
+-- notmuch_all - count messages that match a notmuch query
+-- Copyright (C) 2019  Enric Morales
+--
+-- This file is part of Vicious.
+--
+-- Vicious is free software: you can redistribute it and/or modify
+-- it under the terms of the GNU General Public License as
+-- published by the Free Software Foundation, either version 2 of the
+-- License, or (at your option) any later version.
+--
+-- Vicious is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU Affero General Public License for more details.
+--
+-- You should have received a copy of the GNU Affero General Public License
+-- along with Vicious.  If not, see <https://www.gnu.org/licenses/>.
+
+local tonumber = tonumber
+local helpers = require "vicious.helpers"
+local spawn = require "vicious.spawn"
+
+
+local notmuch = {}
+local output = {}
+
+local function parse(stdout, stderr, exitreason, exitcode)
+   if exitcode == 0 then
+      output.count = tonumber(stdout)
+   else
+      output.count = "N/A"
+   end
+   return output
+end
+
+function notmuch.async(format, warg, callback)
+   local cmd = ("notmuch count '^%s'"):format(warg)
+
+   spawn.easy_async(cmd, function (...) callback(parse(...)) end)
+end
+
+return helpers.setasyncall(notmuch)

--- a/widgets/notmuch_all.lua
+++ b/widgets/notmuch_all.lua
@@ -1,5 +1,5 @@
 -- notmuch_all - count messages that match a notmuch query
--- Copyright (C) 2019  Enric Morales
+-- Copyright (C) 2019  Enric Morales <me@enric.me>
 --
 -- This file is part of Vicious.
 --
@@ -17,26 +17,22 @@
 -- along with Vicious.  If not, see <https://www.gnu.org/licenses/>.
 
 local tonumber = tonumber
-local helpers = require "vicious.helpers"
-local spawn = require "vicious.spawn"
+local helpers = require("vicious.helpers")
+local spawn = require("vicious.spawn")
 
 
 local notmuch = {}
-local output = {}
 
 local function parse(stdout, stderr, exitreason, exitcode)
-   if exitcode == 0 then
-      output.count = tonumber(stdout)
-   else
-      output.count = "N/A"
-   end
-   return output
+    local output = {count = "N/A"}
+    if exitcode == 0 then output.count = tonumber(stdout) end
+    return output
 end
 
 function notmuch.async(format, warg, callback)
-   local cmd = ("notmuch count '^%s'"):format(warg)
+    local cmd = ("notmuch count '^%s'"):format(warg)
 
-   spawn.easy_async(cmd, function (...) callback(parse(...)) end)
+    spawn.easy_async(cmd, function(...) callback(parse(...)) end)
 end
 
 return helpers.setasyncall(notmuch)


### PR DESCRIPTION
Hello everyone! I was using a Notmuch (a mail indexing and threading program, like mu4e) with a widget that I found lying around somewhere. I realised my widget was disabled for a while, so here's a small widget I just created using the async features of Vicious and Awesome WM. Here's how I use it my config:

```lua
-- Mail widget
local widget_mail = wibox.widget.textbox()
local notmuch_exists = awful.util.file_readable("/usr/bin/notmuch") or
		       awful.util.file_readable("/usr/local/bin/notmuch")

if notmuch_exists then
    vicious.register(widget_mail, vicious.widgets.notmuch,
        function (_, args)
            if args["count"] > 0 then
	       return typicons.render("mail")
	    else
	       return ""
	    end
        end, 60, 'tag:inbox AND NOT tag:killed AND tag:unread AND NOT folder:trash')
end
```
And here's the result in my wibox:
![](https://0x0.st/zwc-.png)

It's really simple, but does the job just fine. Let me know what you think.