### PR TITLE
Support different sysctl output formats

### DIFF
--- a/helpers.lua
+++ b/helpers.lua
@@ -245,17 +245,28 @@ function helpers.sysctl_async(path_table, parse)
     spawn.with_line_callback("sysctl " .. path, {
         stdout = function(line)
 	    local separators = {
-	       openbsd = "=",
-	       linux = " = ",
-	       freebsd = ": "
+		freebsd = ": ",
+		linux = " = ",
+		openbsd = "="
 	    }
+            local pattern = ("(.+)%s(.+)"):format(separators[helpers.getos()])
+            local key, value = string.match(line, pattern)
+            ret[key] = value
+	end,
+        stderr = function(line)
+            local messages = {
+                openbsd = {"level name .+ in (.+) is invalid"},
+                linux = {"cannot stat /proc/sys/(.+):",
+                         "permission denied on key '(.+)'"},
+                freebsd = {"unknown oid '(.+)'"}
+            }
 
-	    local pattern = "(.+)%s(.+)"
-	    pattern = pattern:format(separators[helpers.getos()])
-
-            if not string.find(line, "sysctl: unknown oid") then
-                local key, value = string.match(line, pattern)
-                ret[key] = value
+            for i=1,#messages[helpers.getos()] do
+                local key = line:match(messages[helpers.getos()][i])
+                if key then
+                    key = key:gsub("/", ".")
+                    ret[key] = "N/A"
+                end
             end
         end,
         output_done = function() parse(ret) end

--- a/helpers.lua
+++ b/helpers.lua
@@ -244,8 +244,17 @@ function helpers.sysctl_async(path_table, parse)
 
     spawn.with_line_callback("sysctl " .. path, {
         stdout = function(line)
+	    local separators = {
+	       openbsd = "=",
+	       linux = " = ",
+	       freebsd = ": "
+	    }
+
+	    local pattern = "(.+)%s(.+)"
+	    pattern = pattern:format(separators[helpers.getos()])
+
             if not string.find(line, "sysctl: unknown oid") then
-                local key, value = string.match(line, "(.+): (.+)")
+                local key, value = string.match(line, pattern)
                 ret[key] = value
             end
         end,

--- a/helpers.lua
+++ b/helpers.lua
@@ -1,5 +1,6 @@
 ---------------------------------------------------
 -- Licensed under the GNU General Public License v2
+--  * (c) 2019, Enric Morales <me@enric.me>
 --  * (c) 2010, Adrian C. <anrxc@sysphere.org>
 --  * (c) 2009, Rémy C. <shikamaru@mandriva.org>
 --  * (c) 2009, Benedikt Sauer <filmor@gmail.com>

--- a/helpers.lua
+++ b/helpers.lua
@@ -245,32 +245,32 @@ function helpers.sysctl_async(path_table, parse)
 
     spawn.with_line_callback("sysctl " .. path, {
         stdout = function(line)
-	    local separators = {
-		freebsd = ": ",
-		linux = " = ",
-		openbsd = "="
-	    }
+            local separators = {
+                freebsd = ": ",
+                linux = " = ",
+                openbsd = "="
+            }
             local pattern = ("(.+)%s(.+)"):format(separators[helpers.getos()])
             local key, value = string.match(line, pattern)
             ret[key] = value
-	end,
+        end,
         stderr = function(line)
             local messages = {
-                openbsd = {"level name .+ in (.+) is invalid"},
-                linux = {"cannot stat /proc/sys/(.+):",
-                         "permission denied on key '(.+)'"},
-                freebsd = {"unknown oid '(.+)'"}
+                openbsd = { "level name .+ in (.+) is invalid" },
+                linux = { "cannot stat /proc/sys/(.+):",
+                          "permission denied on key '(.+)'" },
+                freebsd = { "unknown oid '(.+)'" }
             }
 
-            for i=1,#messages[helpers.getos()] do
-                local key = line:match(messages[helpers.getos()][i])
+            for _, error_message in ipairs(messages[helpers.getos()]) do
+                local key = line:match(error_message)
                 if key then
                     key = key:gsub("/", ".")
                     ret[key] = "N/A"
                 end
             end
         end,
-        output_done = function() parse(ret) end
+        output_done = function () parse(ret) end
     })
 end
 --  }}}

--- a/helpers.lua
+++ b/helpers.lua
@@ -9,6 +9,7 @@
 ---------------------------------------------------
 
 -- {{{ Grab environment
+local ipairs = ipairs
 local pairs = pairs
 local rawget = rawget
 local require = require
@@ -244,7 +245,7 @@ function helpers.sysctl_async(path_table, parse)
     path = table.concat(path, " ")
 
     spawn.with_line_callback("sysctl " .. path, {
-        stdout = function(line)
+        stdout = function (line)
             local separators = {
                 freebsd = ": ",
                 linux = " = ",
@@ -254,7 +255,7 @@ function helpers.sysctl_async(path_table, parse)
             local key, value = string.match(line, pattern)
             ret[key] = value
         end,
-        stderr = function(line)
+        stderr = function (line)
             local messages = {
                 openbsd = { "level name .+ in (.+) is invalid" },
                 linux = { "cannot stat /proc/sys/(.+):",

--- a/widgets/bat_openbsd.lua
+++ b/widgets/bat_openbsd.lua
@@ -18,6 +18,7 @@
 -- along with Vicious.  If not, see <https://www.gnu.org/licenses/>.
 
 -- {{{ Grab environment
+local pairs = pairs
 local tonumber = tonumber
 local table = {
     insert = table.insert

--- a/widgets/bat_openbsd.lua
+++ b/widgets/bat_openbsd.lua
@@ -29,60 +29,61 @@ local helpers = require("vicious.helpers")
 
 local bat_openbsd = {}
 function bat_openbsd.async(format, warg, callback)
-    local battery = {
-        charging_rate = "hw.sensors.acpi%s.power0",
-        last_full_capacity = "hw.sensors.acpi%s.watthour0",
-        remaining_capacity = "hw.sensors.acpi%s.watthour3",
-        design_capacity = "hw.sensors.acpi%s.watthour4",
-        state = "hw.sensors.acpi%s.raw0",
+    local battery_id = warg or "bat0"
+
+    local fields = {
+	charging_rate = ("hw.sensors.acpi%s.power0"):format(battery_id),
+	last_full_capacity = ("hw.sensors.acpi%s.watthour0"):format(battery_id),
+	remaining_capacity = ("hw.sensors.acpi%s.watthour3"):format(battery_id),
+	design_capacity = ("hw.sensors.acpi%s.watthour4"):format(battery_id),
+	state = ("hw.sensors.acpi%s.raw0"):format(battery_id)
     }
 
-    local sysctl_vars = {}
-    for k, v in pairs(battery) do
-        v = v:format(warg or "bat0")
-        battery[k], sysctl_vars[#sysctl_vars+1] = v, v
-    end
+    local sysctl_args = {}
+    for _, v in pairs(fields) do table.insert(sysctl_args, v) end
 
-    helpers.sysctl_async(sysctl_vars, function(ret)
-    for k, v in pairs(battery) do
-        battery[k] = tonumber(ret[v]:match("(.-) "))
-    end
+    local battery = {}
+    helpers.sysctl_async(sysctl_args, function(ret)
+	    for k, v in pairs(fields) do
+		-- discard the description that comes after the values
+		battery[k] = tonumber(ret[v]:match("(.-) "))
+	    end
 
-    local states = {
-        [0] = "↯",      -- not charging
-        [1] = "-",      -- discharging
-        [2] = "!",      -- critical
-        [3] = "+",      -- charging
-        [4] = "N/A",    -- unknown status
-        [255] = "N/A"   -- unimplemented by the driver
-    }
-    local state = states[battery.state]
+	    local states = {
+		[0] = "↯",      -- not charging
+		[1] = "-",      -- discharging
+		[2] = "!",      -- critical
+		[3] = "+",      -- charging
+		[4] = "N/A",    -- unknown status
+		[255] = "N/A"   -- unimplemented by the driver
+	    }
+	    local state = states[battery.state]
 
-    local charge = tonumber(battery.remaining_capacity
-                                    / battery.last_full_capacity * 100)
+	    local charge = tonumber(battery.remaining_capacity
+				    / battery.last_full_capacity * 100)
 
-    local remaining_time
-    if battery.charging_rate < 1 then
-        remaining_time = "∞"
-    else
-        local raw_time = battery.remaining_capacity / battery.rate
-        local hours, hour_fraction = math.modf(raw_time)
-        local minutes = math.floor(60 * hour_fraction)
-        remaining_time = ("%d:%0.2d"):format(hours, minutes)
-    end
+	    local remaining_time
+	    if battery.charging_rate < 1 then
+		remaining_time = "∞"
+	    else
+		local raw_time = battery.remaining_capacity / battery.rate
+		local hours, hour_fraction = math.modf(raw_time)
+		local minutes = math.floor(60 * hour_fraction)
+		remaining_time = ("%d:%0.2d"):format(hours, minutes)
+	    end
 
-    local wear = math.floor(battery.last_full_capacity,
-                            battery.design_capacity)
+	    local wear = math.floor(battery.last_full_capacity,
+				    battery.design_capacity)
 
-    -- Pass the following arguments to callback function:
-    --  * battery state symbol (↯, -, !, + or N/A)
-    --  * remaining capacity (in percent)
-    --  * remaining time, as reported by the battery
-    --  * wear level (in percent)
-    --  * present_rate (in Watts/hour)
-    return callback({state, charge, remaining_time,
-                        wear, battery.charging_rate})
-    end)
+	    -- Pass the following arguments to callback function:
+	    --  * battery state symbol (↯, -, !, + or N/A)
+	    --  * remaining capacity (in percent)
+	    --  * remaining time, as reported by the battery
+	    --  * wear level (in percent)
+	    --  * present_rate (in Watts/hour)
+	    return callback({ state, charge, remaining_time,
+			    wear, battery.charging_rate })
+	end)
 end
 
 return helpers.setasyncall(bat_openbsd)

--- a/widgets/bat_openbsd.lua
+++ b/widgets/bat_openbsd.lua
@@ -19,6 +19,10 @@
 
 -- {{{ Grab environment
 local tonumber = tonumber
+local table = {
+    insert = table.insert
+}
+
 local math = {
     floor = math.floor,
     modf = math.modf
@@ -32,58 +36,58 @@ function bat_openbsd.async(format, warg, callback)
     local battery_id = warg or "bat0"
 
     local fields = {
-	charging_rate = ("hw.sensors.acpi%s.power0"):format(battery_id),
-	last_full_capacity = ("hw.sensors.acpi%s.watthour0"):format(battery_id),
-	remaining_capacity = ("hw.sensors.acpi%s.watthour3"):format(battery_id),
-	design_capacity = ("hw.sensors.acpi%s.watthour4"):format(battery_id),
-	state = ("hw.sensors.acpi%s.raw0"):format(battery_id)
+        charging_rate = ("hw.sensors.acpi%s.power0"):format(battery_id),
+        last_full_capacity = ("hw.sensors.acpi%s.watthour0"):format(battery_id),
+        remaining_capacity = ("hw.sensors.acpi%s.watthour3"):format(battery_id),
+        design_capacity = ("hw.sensors.acpi%s.watthour4"):format(battery_id),
+        state = ("hw.sensors.acpi%s.raw0"):format(battery_id)
     }
 
     local sysctl_args = {}
     for _, v in pairs(fields) do table.insert(sysctl_args, v) end
 
     local battery = {}
-    helpers.sysctl_async(sysctl_args, function(ret)
-	    for k, v in pairs(fields) do
-		-- discard the description that comes after the values
-		battery[k] = tonumber(ret[v]:match("(.-) "))
-	    end
+    helpers.sysctl_async(sysctl_args, function (ret)
+            for k, v in pairs(fields) do
+                -- discard the description that comes after the values
+                battery[k] = tonumber(ret[v]:match("(.-) "))
+            end
 
-	    local states = {
-		[0] = "↯",      -- not charging
-		[1] = "-",      -- discharging
-		[2] = "!",      -- critical
-		[3] = "+",      -- charging
-		[4] = "N/A",    -- unknown status
-		[255] = "N/A"   -- unimplemented by the driver
-	    }
-	    local state = states[battery.state]
+            local states = {
+                [0] = "↯",      -- not charging
+                [1] = "-",      -- discharging
+                [2] = "!",      -- critical
+                [3] = "+",      -- charging
+                [4] = "N/A",    -- unknown status
+                [255] = "N/A"   -- unimplemented by the driver
+            }
+            local state = states[battery.state]
 
-	    local charge = tonumber(battery.remaining_capacity
-				    / battery.last_full_capacity * 100)
+            local charge = tonumber(battery.remaining_capacity
+                                    / battery.last_full_capacity * 100)
 
-	    local remaining_time
-	    if battery.charging_rate < 1 then
-		remaining_time = "∞"
-	    else
-		local raw_time = battery.remaining_capacity / battery.rate
-		local hours, hour_fraction = math.modf(raw_time)
-		local minutes = math.floor(60 * hour_fraction)
-		remaining_time = ("%d:%0.2d"):format(hours, minutes)
-	    end
+            local remaining_time
+            if battery.charging_rate < 1 then
+                remaining_time = "∞"
+            else
+                local raw_time = battery.remaining_capacity / battery.rate
+                local hours, hour_fraction = math.modf(raw_time)
+                local minutes = math.floor(60 * hour_fraction)
+                remaining_time = ("%d:%0.2d"):format(hours, minutes)
+            end
 
-	    local wear = math.floor(battery.last_full_capacity,
-				    battery.design_capacity)
+            local wear = math.floor(battery.last_full_capacity,
+                                    battery.design_capacity)
 
-	    -- Pass the following arguments to callback function:
-	    --  * battery state symbol (↯, -, !, + or N/A)
-	    --  * remaining capacity (in percent)
-	    --  * remaining time, as reported by the battery
-	    --  * wear level (in percent)
-	    --  * present_rate (in Watts/hour)
-	    return callback({ state, charge, remaining_time,
-			    wear, battery.charging_rate })
-	end)
+            -- Pass the following arguments to callback function:
+            --  * battery state symbol (↯, -, !, + or N/A)
+            --  * remaining capacity (in percent)
+            --  * remaining time, as reported by the battery
+            --  * wear level (in percent)
+            --  * present_rate (in Watts/hour)
+            return callback({ state, charge, remaining_time,
+                              wear, battery.charging_rate })
+    end)
 end
 
 return helpers.setasyncall(bat_openbsd)

--- a/widgets/bat_openbsd.lua
+++ b/widgets/bat_openbsd.lua
@@ -19,67 +19,70 @@
 
 -- {{{ Grab environment
 local tonumber = tonumber
-local math = { floor = math.floor, modf = math.modf }
+local math = {
+    floor = math.floor,
+    modf = math.modf
+}
 
-local helpers = require"vicious.helpers"
-local spawn = require"vicious.spawn"
+local helpers = require("vicious.helpers")
 -- }}}
 
-local STATES = { [0] = "↯",         -- not charging
-                 [1] = "-",         -- discharging
-                 [2] = "!",         -- critical
-                 [3] = "+",         -- charging
-                 [4] = "N/A",       -- unknown status
-                 [255] = "N/A" }    -- unimplemented by the driver
+local bat_openbsd = {}
+function bat_openbsd.async(format, warg, callback)
+    local battery = {
+        charging_rate = "hw.sensors.acpi%s.power0",
+        last_full_capacity = "hw.sensors.acpi%s.watthour0",
+        remaining_capacity = "hw.sensors.acpi%s.watthour3",
+        design_capacity = "hw.sensors.acpi%s.watthour4",
+        state = "hw.sensors.acpi%s.raw0",
+    }
 
-return helpers.setasyncall{
-    async = function (format, warg, callback)
-        local filter = "hw.sensors.acpi" .. (warg or "bat0")
-        local pattern = filter .. ".(%S+)=(%S+)"
-        local bat_info = {}
+    local sysctl_vars = {}
+    for k, v in pairs(battery) do
+        v = v:format(warg or "bat0")
+        battery[k], sysctl_vars[#sysctl_vars+1] = v, v
+    end
 
-        spawn.with_line_callback_with_shell(
-            ("sysctl -a | grep '^%s'"):format(filter),
-            { stdout = function (line)
-                  for key, value in line:gmatch(pattern) do
-                      bat_info[key] = value
-                  end
-              end,
-              output_done = function ()
-                  -- current state
-                  local state = STATES[tonumber(bat_info.raw0)]
+    helpers.sysctl_async(sysctl_vars, function(ret)
+    for k, v in pairs(battery) do
+        battery[k] = tonumber(ret[v]:match("(.-) "))
+    end
 
-                  -- battery capacity in percent
-                  local percent = tonumber(
-                      bat_info.watthour3 / bat_info.watthour0 * 100)
+    local states = {
+        [0] = "↯",      -- not charging
+        [1] = "-",      -- discharging
+        [2] = "!",      -- critical
+        [3] = "+",      -- charging
+        [4] = "N/A",    -- unknown status
+        [255] = "N/A"   -- unimplemented by the driver
+    }
+    local state = states[battery.state]
 
-                  local time
-                  if tonumber(bat_info.power0) < 1 then
-                      time = "∞"
-                  else
-                      local raw_time = bat_info.watthour3 / bat_info.power0
-                      local hours, hour_fraction = math.modf(raw_time)
-                      local minutes = math.floor(60 * hour_fraction)
-                      time = ("%d:%0.2d"):format(hours, minutes)
-                  end
+    local charge = tonumber(battery.remaining_capacity
+                                    / battery.last_full_capacity * 100)
 
-                  -- calculate wear level from (last full / design) capacity
-                  local wear = "N/A"
-                  if bat_info.watthour0 and bat_info.watthour4 then
-                      local l_full = tonumber(bat_info.watthour0)
-                      local design = tonumber(bat_info.watthour4)
-                      wear = math.floor(l_full / design * 100)
-                  end
+    local remaining_time
+    if battery.charging_rate < 1 then
+        remaining_time = "∞"
+    else
+        local raw_time = battery.remaining_capacity / battery.rate
+        local hours, hour_fraction = math.modf(raw_time)
+        local minutes = math.floor(60 * hour_fraction)
+        remaining_time = ("%d:%0.2d"):format(hours, minutes)
+    end
 
-                  -- dis-/charging rate as presented by battery
-                  local rate = bat_info.power0
+    local wear = math.floor(battery.last_full_capacity,
+                            battery.design_capacity)
 
-                  -- Pass the following arguments to callback function:
-                  --  * battery state symbol (↯, -, !, + or N/A)
-                  --  * remaining_capacity (in percent)
-                  --  * remaining_time, by battery
-                  --  * wear level (in percent)
-                  --  * present_rate (in Watts)
-                  callback{state, percent, time, wear, rate}
-              end })
-    end }
+    -- Pass the following arguments to callback function:
+    --  * battery state symbol (↯, -, !, + or N/A)
+    --  * remaining capacity (in percent)
+    --  * remaining time, as reported by the battery
+    --  * wear level (in percent)
+    --  * present_rate (in Watts/hour)
+    return callback({state, charge, remaining_time,
+                        wear, battery.charging_rate})
+    end)
+end
+
+return helpers.setasyncall(bat_openbsd)


### PR DESCRIPTION
In the io.popen deprecation PR @McSinyx mentioned that different platforms use different ways of outputting the sysctl info. For instance, in OpenBSD we use "=" between key and value, FreeBSD uses ": " and GNU/Linux uses " = ". Well, I think the sysctl helper should support that and account the difference between systems.

Here's a PR that intends to add such support. It's pretty straightforward and Works For Me(TM) BUT it should be tested in other systems. I've no Linux or FreeBSD systems with Awesome WM around here so please try this PR and let me know if it works for you.

This snippet in `rc.lua` was used to test it:
```lua
helpers = require("vicious.helpers")
helpers.sysctl_async({ "hw.usermem",
		       "hw.physmem"},
		     function(ret)
			for k, v in pairs(ret)
			do print(k, v) end
		     end
)
```
Yielding this output:

![](https://0x0.st/zwT6.png)

Cheers,
Enric
