### PR TITLE
[cpu_openbsd] Add a CPU usage widget for OpenBSD

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,11 +170,14 @@ Provides CPU usage for all available CPUs/cores. Since this widget type give
 CPU utilization between two consecutive calls, it is recommended to enable
 caching if it is used to register multiple widgets (#71).
 
-Supported platforms: GNU/Linux, FreeBSD.
+Supported platforms: GNU/Linux, FreeBSD, OpenBSD.
 
-Returns an array containing:
+On FreeBSD and Linux returns an array containing:
 * `$1`: usage of all CPUs/cores
 * `$2`, `$3`, etc. are respectively the usage of 1st, 2nd, etc. CPU/core
+
+On OpenBSD returns an array containing:
+* `$1`: usage of all CPUs/cores
 
 ### vicious.widgets.cpufreq
 

--- a/widgets/cpu_openbsd.lua
+++ b/widgets/cpu_openbsd.lua
@@ -30,7 +30,7 @@ local cpu_openbsd = {}
 
 -- Initialize the table that will contain the ticks spent in each subsystem
 -- values: user, nice, system, spin, interrupts, idle
-cpu_openbsd.ticks = { 0, 0, 0, 0, 0, 0 }
+local ticks = { 0, 0, 0, 0, 0, 0 }
 
 function cpu_openbsd.async(format, warg, callback)
     helpers.sysctl_async({ "kern.cp_time" },
@@ -43,7 +43,7 @@ function cpu_openbsd.async(format, warg, callback)
             local period_ticks = {}
             for i = 1, 6 do
                 table.insert(period_ticks,
-                             current_ticks[i] - cpu_openbsd.ticks[i])
+                             current_ticks[i] - ticks[i])
             end
 
             local cpu_total, cpu_busy = 0, 0
@@ -52,7 +52,7 @@ function cpu_openbsd.async(format, warg, callback)
 
             local cpu_usage = math.ceil((cpu_busy / cpu_total) * 100)
 
-            cpu_openbsd.ticks = current_ticks
+            ticks = current_ticks
             return callback({ cpu_usage })
         end)
 end

--- a/widgets/cpu_openbsd.lua
+++ b/widgets/cpu_openbsd.lua
@@ -1,0 +1,60 @@
+-- cpu_openbsd.lua - provide CPU usage on OpenBSD
+-- Copyright (C) 2019  Enric Morales
+--
+-- This file is part of Vicious.
+--
+-- Vicious is free software: you can redistribute it and/or modify
+-- it under the terms of the GNU General Public License as
+-- published by the Free Software Foundation, either version 2 of the
+-- License, or (at your option) any later version.
+--
+-- Vicious is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU Affero General Public License for more details.
+--
+-- You should have received a copy of the GNU Affero General Public License
+-- along with Vicious.  If not, see <https://www.gnu.org/licenses/>.
+
+local math = { ceil = math.ceil }
+local string = { gmatch = string.gmatch }
+local table = { insert = table.insert }
+local tonumber = tonumber
+
+local helpers = require("vicious.helpers")
+
+
+-- cpu_openbsd: provides both a helper function that allows reading
+-- the CPU usage on OpenBSD systems.
+local cpu_openbsd = {}
+
+-- Initialize the table that will contain the ticks spent in each subsystem
+-- values: user, nice, system, spin, interrupts, idle
+cpu_openbsd.ticks = { 0, 0, 0, 0, 0, 0 }
+
+function cpu_openbsd.async(format, warg, callback)
+    helpers.sysctl_async({ "kern.cp_time" },
+	function (ret)
+	    local current_ticks = {}
+	    for match in string.gmatch(ret["kern.cp_time"], "(%d+)") do
+		table.insert(current_ticks, tonumber(match))
+	    end
+
+	    local period_ticks = {}
+	    for i=1, 6 do
+		table.insert(period_ticks,
+			     current_ticks[i] - cpu_openbsd.ticks[i])
+	    end
+
+	    local cpu_total, cpu_busy = 0, 0
+	    for i = 1, 6 do cpu_total = cpu_total + period_ticks[i] end
+	    for i = 1, 5 do cpu_busy = cpu_busy + period_ticks[i] end
+
+	    local cpu_usage = math.ceil((cpu_busy / cpu_total) * 100 )
+
+	    cpu_openbsd.ticks = current_ticks
+	    return callback({ cpu_usage })
+        end)
+end
+
+return helpers.setasyncall(cpu_openbsd)

--- a/widgets/cpu_openbsd.lua
+++ b/widgets/cpu_openbsd.lua
@@ -50,7 +50,7 @@ function cpu_openbsd.async(format, warg, callback)
             for i = 1, 6 do cpu_total = cpu_total + period_ticks[i] end
             for i = 1, 5 do cpu_busy = cpu_busy + period_ticks[i] end
 
-            local cpu_usage = math.ceil((cpu_busy / cpu_total) * 100 )
+            local cpu_usage = math.ceil((cpu_busy / cpu_total) * 100)
 
             cpu_openbsd.ticks = current_ticks
             return callback({ cpu_usage })

--- a/widgets/cpu_openbsd.lua
+++ b/widgets/cpu_openbsd.lua
@@ -1,5 +1,4 @@
--- cpu_openbsd.lua - provide CPU usage on OpenBSD
--- Copyright (C) 2019  Enric Morales
+-- Copyright (C) 2019 Enric Morales
 --
 -- This file is part of Vicious.
 --
@@ -11,9 +10,9 @@
 -- Vicious is distributed in the hope that it will be useful,
 -- but WITHOUT ANY WARRANTY; without even the implied warranty of
 -- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
--- GNU Affero General Public License for more details.
+-- GNU General Public License for more details.
 --
--- You should have received a copy of the GNU Affero General Public License
+-- You should have received a copy of the GNU General Public License
 -- along with Vicious.  If not, see <https://www.gnu.org/licenses/>.
 
 local math = { ceil = math.ceil }

--- a/widgets/cpu_openbsd.lua
+++ b/widgets/cpu_openbsd.lua
@@ -33,26 +33,26 @@ cpu_openbsd.ticks = { 0, 0, 0, 0, 0, 0 }
 
 function cpu_openbsd.async(format, warg, callback)
     helpers.sysctl_async({ "kern.cp_time" },
-	function (ret)
-	    local current_ticks = {}
-	    for match in string.gmatch(ret["kern.cp_time"], "(%d+)") do
-		table.insert(current_ticks, tonumber(match))
-	    end
+        function (ret)
+            local current_ticks = {}
+            for match in string.gmatch(ret["kern.cp_time"], "(%d+)") do
+                table.insert(current_ticks, tonumber(match))
+            end
 
-	    local period_ticks = {}
-	    for i=1, 6 do
-		table.insert(period_ticks,
-			     current_ticks[i] - cpu_openbsd.ticks[i])
-	    end
+            local period_ticks = {}
+            for i = 1, 6 do
+                table.insert(period_ticks,
+                             current_ticks[i] - cpu_openbsd.ticks[i])
+            end
 
-	    local cpu_total, cpu_busy = 0, 0
-	    for i = 1, 6 do cpu_total = cpu_total + period_ticks[i] end
-	    for i = 1, 5 do cpu_busy = cpu_busy + period_ticks[i] end
+            local cpu_total, cpu_busy = 0, 0
+            for i = 1, 6 do cpu_total = cpu_total + period_ticks[i] end
+            for i = 1, 5 do cpu_busy = cpu_busy + period_ticks[i] end
 
-	    local cpu_usage = math.ceil((cpu_busy / cpu_total) * 100 )
+            local cpu_usage = math.ceil((cpu_busy / cpu_total) * 100 )
 
-	    cpu_openbsd.ticks = current_ticks
-	    return callback({ cpu_usage })
+            cpu_openbsd.ticks = current_ticks
+            return callback({ cpu_usage })
         end)
 end
 

--- a/widgets/cpu_openbsd.lua
+++ b/widgets/cpu_openbsd.lua
@@ -1,4 +1,5 @@
--- Copyright (C) 2019 Enric Morales
+-- CPU usage widget type for OpenBSD
+-- Copyright (C) 2019  Enric Morales
 --
 -- This file is part of Vicious.
 --


### PR DESCRIPTION
Hello everyone!

This PR adds a CPU usage widget for OpenBSD. It currently only outputs the usage across all cores, since I can't seem to be able to use the per-core info. As you can see in ![this video](https://thumbs.gfycat.com/AbleHarmlessBlacknorwegianelkhound-mobile.mp4) the output is reasonable. The usage is currently calculated from all the values (system, user, nice, interrupt). Let me know if it's alright style-wise. As for functionality, it is pretty barebones but IMHO sufficient.

Cheers,

Enric