### PR TITLE
[contrib.openweather] added missing app id and some additional return variables

### DIFF
--- a/contrib/openweather_all.lua
+++ b/contrib/openweather_all.lua
@@ -19,8 +19,6 @@
 -- along with Vicious.  If not, see <https://www.gnu.org/licenses/>.
 -- {{{ Grab environment
 local tonumber = tonumber
-local io = {popen = io.popen}
-local setmetatable = setmetatable
 local string = {match = string.match}
 local math = {ceil = math.ceil, floor = math.floor}
 local helpers = require "vicious.helpers"

--- a/docs/source/contrib.rst
+++ b/docs/source/contrib.rst
@@ -133,12 +133,15 @@ vicious.contrib.net
 vicious.contrib.openweather
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Provides weather information for a requested city
+Provides weather information for a requested city from OpenWeatherMap (OWM)
 
-* Argument: OpenWeatherMap city ID, e.g. ``"1275339"``
-* Returns a table with string keys: ``${city}``, ``${wind deg}``,
-  ``${wind aim}``, ``${wind kmh}``, ``${wind mps}``, ``${sky}``,
-  ``${weather}``, ``${temp c}``, ``${humid}`` and ``${press}``
+* Argument: a table containing the fields ``city_id`` with the OWM city ID, e.g.
+  ``"2643743"`` and ``app_id`` with the the OWM app ID, e.g
+  ``"4c57f0c88d9844630327623633ce269cf826ab99"``
+* Returns a table with string keys: ``${city}``, ``${humid}``, ``${press}``,
+  ``${sky}``, ``${sunrise}``, ``${sunset}``, ``${temp c}``, ``${temp max c}``,
+  ``${temp min c}``, ``${weather}``, ``${wind aim}``, ``${wind deg}``,
+  ``${wind kmh}`` and ``${wind mps}``,
 
 vicious.contrib.nvinf
 ^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
The current implementation is not working due to the lack of an API key (appid).

### Changes
 * Added app_id to warg.
 * New return variables {temp min c}, {temp… max c}, {sunrise} and {sunset}

### New behavior

 * Argument: a table with fields `city_id` (e.g. number: 2643743) and `app_id` (e.g string: '4c57f0c88d9844630327623633ce269cf826ab99')
 * Returns a table with string keys: `${city}`, `${humid}`, `${press}`, `${sky}`, `${sunrise}`, `${sunset}`, `${temp c}`, `${temp max c}`, `${temp min c}`, `${weather}`, `${wind aim}`, `${wind deg}`, `${wind kmh}`, `${wind mps}`
