### PR TITLE
vicious.widgets.gmail docs update

### DIFF
--- a/docs/source/widgets.rst
+++ b/docs/source/widgets.rst
@@ -150,8 +150,10 @@ Provides count of new and subject of last e-mail on Gmail.
 Supported platform: platform independent, requiring ``curl``.
 
 This widget expects login information in your ``~/.netrc`` file, e.g.
-``machine mail.google.com login user password pass`` and you have to disable
-`two step verification`_.  `Allow access for less secure apps`_ afterwards.
+``machine mail.google.com login user password pass``. If you have 2FA
+account, you can use 'App password' which is created on
+`Google Security page`_. Otherwise, you have to disable
+`two step verification`_ and `allow access for less secure apps`_.
 
 .. caution::
 
@@ -501,7 +503,8 @@ Supported platforms: GNU/Linux.
   and ``${sign}`` (signal level, in dBm)
 
 .. _strftime(3): https://linux.die.net/man/3/strftime
+.. _Google Security page: https://myaccount.google.com/security?gar=1
 .. _two step verification: https://support.google.com/accounts/answer/1064203
-.. _Allow access for less secure apps:
+.. _allow access for less secure apps:
    https://www.google.com/settings/security/lesssecureapps
 .. _amixer(1): https://linux.die.net/man/1/amixer


### PR DESCRIPTION
more info on getting gmail password. Fixes #105