### PR TITLE
Add ability to send arbitrary commands to MPD

### DIFF
--- a/docs/source/widgets.rst
+++ b/docs/source/widgets.rst
@@ -290,6 +290,11 @@ Supported platforms: platform independent (required tools: ``curl``).
   ``${random}``, ``${repeat}``, ``${state}``, ``${Artist}``, ``${Title}``,
   ``${Album}``, ``${Genre}`` and optionally ``${Name}`` and ``${file}``.
 
+In addition, some common mpd commands are available as functions:
+``playpause``, ``play``, ``pause``, ``stop``, ``next``, ``previous``.
+Arguments are of the same form as above, and no value is returned,
+e.g. ``vicious.widgets.mpd.playpause()``.
+
 vicious.widgets.net
 -------------------
 


### PR DESCRIPTION
This PR allows the user to send commands to MPD.
I have currently implemented wrappers for some of the more common commands. Maybe it would be a good idea to expose the `build_cmd` to allow users to add their own.

I fully understand if you feel this is not in the scope of this library :)