### PR TITLE
Made module require relative

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -201,7 +201,7 @@ For example,
 
    local awful = require("awful")
 
-   local helpers = require("vicious.helpers")
+   local helpers = require((...):match(".*vicious") .. ".helpers")
 
 String Quotes
 ^^^^^^^^^^^^^

--- a/contrib/ac_linux.lua
+++ b/contrib/ac_linux.lua
@@ -21,7 +21,7 @@
 local tonumber = tonumber
 local setmetatable = setmetatable
 local string = { format = string.format }
-local helpers = require("vicious.helpers")
+local helpers = require((...):match(".*vicious") .. ".helpers")
 local math = {
     min = math.min,
     floor = math.floor

--- a/contrib/ati_linux.lua
+++ b/contrib/ati_linux.lua
@@ -21,7 +21,7 @@
 local tonumber = tonumber
 local io = { open = io.open }
 local setmetatable = setmetatable
-local helpers = require("vicious.helpers")
+local helpers = require((...):match(".*vicious") .. ".helpers")
 local string = {
     sub = string.sub,
     match = string.match,

--- a/contrib/btc_all.lua
+++ b/contrib/btc_all.lua
@@ -20,8 +20,8 @@
 
 -- {{{ Grab environment
 local pcall = pcall
-local helpers = require("vicious.helpers")
-local spawn = require("vicious.spawn")
+local helpers = require((...):match(".*vicious") .. ".helpers")
+local spawn = require((...):match(".*vicious") .. ".spawn")
 
 local success, json = pcall(require, "cjson")
 if not success then

--- a/contrib/dio_linux.lua
+++ b/contrib/dio_linux.lua
@@ -22,7 +22,7 @@ local ipairs = ipairs
 local setmetatable = setmetatable
 local table = { insert = table.insert }
 local string = { gmatch = string.gmatch }
-local helpers = require("vicious.helpers")
+local helpers = require((...):match(".*vicious") .. ".helpers")
 -- }}}
 
 

--- a/contrib/init.lua
+++ b/contrib/init.lua
@@ -20,11 +20,11 @@
 
 -- {{{ Setup environment
 local setmetatable = setmetatable
-local wrequire = require("vicious.helpers").wrequire
+local wrequire = require((...):match(".*vicious") .. ".helpers").wrequire
 
 -- Vicious: widgets for the awesome window manager
 -- vicious.contrib
-local contrib = { _NAME = "vicious.contrib" }
+local contrib = { _NAME = (...):match(".*vicious") .. ".contrib" }
 -- }}}
 
 -- Load modules at runtime as needed

--- a/contrib/mpc_all.lua
+++ b/contrib/mpc_all.lua
@@ -24,7 +24,7 @@ local type = type
 local io = { popen = io.popen }
 local setmetatable = setmetatable
 local string = { find = string.find }
-local helpers = require("vicious.helpers")
+local helpers = require((...):match(".*vicious") .. ".helpers")
 -- }}}
 
 

--- a/contrib/net_linux.lua
+++ b/contrib/net_linux.lua
@@ -27,7 +27,7 @@ local os = { time = os.time }
 local io = { lines = io.lines }
 local setmetatable = setmetatable
 local string = { match = string.match }
-local helpers = require("vicious.helpers")
+local helpers = require((...):match(".*vicious") .. ".helpers")
 -- }}}
 
 

--- a/contrib/nvinf_all.lua
+++ b/contrib/nvinf_all.lua
@@ -22,7 +22,7 @@ local tonumber = tonumber
 local io = { popen = io.popen }
 local string = { gmatch = string.gmatch }
 local setmetatable = setmetatable
-local helpers = require("vicious.helpers")
+local helpers = require((...):match(".*vicious") .. ".helpers")
 -- }}}
 
 

--- a/contrib/openweather_all.lua
+++ b/contrib/openweather_all.lua
@@ -21,8 +21,8 @@
 local tonumber = tonumber
 local string = {match = string.match}
 local math = {ceil = math.ceil, floor = math.floor}
-local helpers = require "vicious.helpers"
-local spawn = require "vicious.spawn"
+local helpers = require (...):match(".*vicious") .. ".helpers"
+local spawn = require (...):match(".*vicious") .. ".spawn"
 -- }}}
 
 -- Openweather: provides weather information for a requested station

--- a/contrib/wpa_all.lua
+++ b/contrib/wpa_all.lua
@@ -21,7 +21,7 @@
 local tonumber = tonumber
 local math = { ceil = math.ceil }
 local setmetatable = setmetatable
-local helpers = require("vicious.helpers")
+local helpers = require((...):match(".*vicious") .. ".helpers")
 local io = {
     open = io.open,
     popen = io.popen

--- a/docs/source/contrib.rst
+++ b/docs/source/contrib.rst
@@ -15,8 +15,8 @@ Or you can load them in your rc.lua after you require Vicious:
 
 .. code-block:: lua
 
-   local vicious = require"vicious"
-   vicious.contrib = require"vicious.contrib"
+   local vicious = require(...):match(".*vicious") .. ".
+   vicious.contrib = require(...):match(".*vicious") .. ".contrib"
 
 Widget Types
 ------------

--- a/docs/source/usage-awesome.rst
+++ b/docs/source/usage-awesome.rst
@@ -16,7 +16,7 @@ Then add the following to the top of your ``rc.lua``:
 
 .. code-block:: lua
 
-   local vicious = require("vicious")
+   local vicious = require((...):match(".*vicious") .. ".)
 
 vicious.register
 ----------------

--- a/docs/source/usage-lua.rst
+++ b/docs/source/usage-lua.rst
@@ -8,7 +8,7 @@ to be used stand-alone or to feed widgets of any window manager
 
 .. code-block:: lua
 
-   > widgets = require("vicious.widgets.init")
+   > widgets = require((...):match(".*vicious") .. ".widgets.init")
    > print(widgets.volume(nil, "Master")[1])
    100
 

--- a/helpers.lua
+++ b/helpers.lua
@@ -48,7 +48,7 @@ local string = {
 local table = { concat = table.concat }
 local pcall = pcall
 local assert = assert
-local spawn = require("vicious.spawn")
+local spawn = require((...):match(".*vicious") .. ".spawn")
 -- }}}
 
 

--- a/init.lua
+++ b/init.lua
@@ -38,7 +38,7 @@ local table = {
     insert  = table.insert,
     remove  = table.remove
 }
-local helpers = require("vicious.helpers")
+local helpers = require((...) .. ".helpers")
 local dstatus, debug = pcall(require, "gears.debug")
 local stderr = io.stderr
 local warn
@@ -50,8 +50,8 @@ end
 
 -- Vicious: widgets for the awesome window manager
 local vicious = {}
-vicious.widgets = require("vicious.widgets")
---vicious.contrib = require("vicious.contrib")
+vicious.widgets = require((...) .. ".widgets")
+--vicious.contrib = require((...) .. ".contrib")
 
 -- Initialize tables
 local timers       = {}

--- a/templates/async.lua
+++ b/templates/async.lua
@@ -16,7 +16,7 @@
 -- You should have received a copy of the GNU General Public License
 -- along with Vicious.  If not, see <https://www.gnu.org/licenses/>.
 
-local helpers = require"vicious.helpers"
+local helpers = require(...):match(".*vicious") .. ".helpers"
 
 return helpers.setasyncall{
     async = function (format, warg, callback)

--- a/templates/sync.lua
+++ b/templates/sync.lua
@@ -16,7 +16,7 @@
 -- You should have received a copy of the GNU General Public License
 -- along with Vicious.  If not, see <https://www.gnu.org/licenses/>.
 
-local helpers = require"vicious.helpers"
+local helpers = require(...):match(".*vicious") .. ".helpers"
 
 return helpers.setcall(function (format, warg)
     -- Do the processing and return a table here.

--- a/widgets/bat_freebsd.lua
+++ b/widgets/bat_freebsd.lua
@@ -25,8 +25,8 @@ local string = {
     format = string.format
 }
 
-local helpers = require("vicious.helpers")
-local spawn = require("vicious.spawn")
+local helpers = require((...):match(".*vicious") .. ".helpers")
+local spawn = require((...):match(".*vicious") .. ".spawn")
 -- }}}
 
 -- Battery: provides battery level of requested battery

--- a/widgets/bat_linux.lua
+++ b/widgets/bat_linux.lua
@@ -28,7 +28,7 @@ local math = {
     floor = math.floor
 }
 
-local helpers = require"vicious.helpers"
+local helpers = require(...):match(".*vicious") .. ".helpers"
 -- }}}
 
 -- {{{ Battery widget type

--- a/widgets/bat_openbsd.lua
+++ b/widgets/bat_openbsd.lua
@@ -29,7 +29,7 @@ local math = {
     modf = math.modf
 }
 
-local helpers = require("vicious.helpers")
+local helpers = require((...):match(".*vicious") .. ".helpers")
 -- }}}
 
 local bat_openbsd = {}

--- a/widgets/cmus_all.lua
+++ b/widgets/cmus_all.lua
@@ -23,8 +23,8 @@ local type = type
 local tonumber = tonumber
 local os = { getenv = os.getenv }
 
-local helpers = require"vicious.helpers"
-local spawn = require"vicious.spawn"
+local helpers = require(...):match(".*vicious") .. ".helpers"
+local spawn = require(...):match(".*vicious") .. ".spawn"
 -- }}}
 
 local CMUS_SOCKET = helpers.shellquote(os.getenv"CMUS_SOCKET")

--- a/widgets/cpu_freebsd.lua
+++ b/widgets/cpu_freebsd.lua
@@ -21,7 +21,7 @@
 local math = { floor = math.floor }
 local string = { gmatch = string.gmatch }
 
-local helpers = require("vicious.helpers")
+local helpers = require((...):match(".*vicious") .. ".helpers")
 -- }}}
 
 -- Cpu: provides CPU usage for all available CPUs/cores

--- a/widgets/cpu_linux.lua
+++ b/widgets/cpu_linux.lua
@@ -29,7 +29,7 @@ local string = {
     gmatch = string.gmatch
 }
 
-local helpers = require"vicious.helpers"
+local helpers = require(...):match(".*vicious") .. ".helpers"
 -- }}}
 
 -- Initialize function tables

--- a/widgets/cpu_openbsd.lua
+++ b/widgets/cpu_openbsd.lua
@@ -21,7 +21,7 @@ local string = { gmatch = string.gmatch }
 local table = { insert = table.insert }
 local tonumber = tonumber
 
-local helpers = require("vicious.helpers")
+local helpers = require((...):match(".*vicious") .. ".helpers")
 
 
 -- cpu_openbsd: provides both a helper function that allows reading

--- a/widgets/cpufreq_freebsd.lua
+++ b/widgets/cpufreq_freebsd.lua
@@ -19,7 +19,7 @@
 
 -- {{{ Grab environment
 local tonumber = tonumber
-local helpers = require("vicious.helpers")
+local helpers = require((...):match(".*vicious") .. ".helpers")
 -- }}}
 
 -- Cpufreq: provides freq, voltage and governor info for a requested CPU

--- a/widgets/cpufreq_linux.lua
+++ b/widgets/cpufreq_linux.lua
@@ -19,7 +19,7 @@
 
 -- {{{ Grab environment
 local tonumber = tonumber
-local helpers = require("vicious.helpers")
+local helpers = require((...):match(".*vicious") .. ".helpers")
 -- }}}
 
 local GOVERNOR_STATE = {

--- a/widgets/cpuinf_linux.lua
+++ b/widgets/cpuinf_linux.lua
@@ -21,7 +21,7 @@
 local tonumber = tonumber
 local io = { lines = io.lines }
 local string = { gmatch = string.gmatch }
-local helpers = require"vicious.helpers"
+local helpers = require(...):match(".*vicious") .. ".helpers"
 -- }}}
 
 -- {{{ CPU Information widget type

--- a/widgets/date_all.lua
+++ b/widgets/date_all.lua
@@ -21,7 +21,7 @@
 
 -- {{{ Grab environment
 local os = { date = os.date, time = os.time }
-local helpers = require"vicious.helpers"
+local helpers = require(...):match(".*vicious") .. ".helpers"
 -- }}}
 
 return helpers.setcall(function (format, warg)

--- a/widgets/dio_linux.lua
+++ b/widgets/dio_linux.lua
@@ -23,7 +23,7 @@ local pairs = pairs
 local io = { lines = io.lines }
 local os = { time = os.time, difftime = os.difftime }
 
-local helpers = require"vicious.helpers"
+local helpers = require(...):match(".*vicious") .. ".helpers"
 -- }}}
 
 -- Initialize function tables

--- a/widgets/fanspeed_freebsd.lua
+++ b/widgets/fanspeed_freebsd.lua
@@ -21,7 +21,7 @@
 local tonumber = tonumber
 local type = type
 
-local helpers = require("vicious.helpers")
+local helpers = require((...):match(".*vicious") .. ".helpers")
 -- }}}
 
 -- fanspeed: provides speed level of fans

--- a/widgets/fs_all.lua
+++ b/widgets/fs_all.lua
@@ -23,8 +23,8 @@
 -- {{{ Grab environment
 local tonumber = tonumber
 
-local helpers = require"vicious.helpers"
-local spawn = require"vicious.spawn"
+local helpers = require(...):match(".*vicious") .. ".helpers"
+local spawn = require(...):match(".*vicious") .. ".spawn"
 -- }}}
 
 -- Mebibyte and gibibyte respectively, because backward compatibility

--- a/widgets/gmail_all.lua
+++ b/widgets/gmail_all.lua
@@ -24,8 +24,8 @@ local type = type
 local tonumber = tonumber
 local string = { match = string.match }
 
-local helpers = require("vicious.helpers")
-local spawn = require("vicious.spawn")
+local helpers = require((...):match(".*vicious") .. ".helpers")
+local spawn = require((...):match(".*vicious") .. ".spawn")
 -- }}}
 
 -- Gmail: provides count of new and subject of last e-mail on Gmail

--- a/widgets/hddtemp_linux.lua
+++ b/widgets/hddtemp_linux.lua
@@ -21,8 +21,8 @@
 -- {{{ Grab environment
 local tonumber = tonumber
 
-local helpers = require"vicious.helpers"
-local spawn = require"vicious.spawn"
+local helpers = require(...):match(".*vicious") .. ".helpers"
+local spawn = require(...):match(".*vicious") .. ".spawn"
 -- }}}
 
 -- Hddtemp: provides hard drive temperatures using the hddtemp daemon

--- a/widgets/hwmontemp_linux.lua
+++ b/widgets/hwmontemp_linux.lua
@@ -22,8 +22,8 @@ local type = type
 local tonumber = tonumber
 local io = { open = io.open }
 
-local helpers = require"vicious.helpers"
-local spawn = require"vicious.spawn"
+local helpers = require(...):match(".*vicious") .. ".helpers"
+local spawn = require(...):match(".*vicious") .. ".spawn"
 
 local pathcache = {}
 

--- a/widgets/init.lua
+++ b/widgets/init.lua
@@ -19,6 +19,6 @@
 -- along with Vicious.  If not, see <https://www.gnu.org/licenses/>.
 
 local setmetatable = setmetatable
-local wrequire = require("vicious.helpers").wrequire
+local wrequire = require((...):match(".*vicious") .. ".helpers").wrequire
 
-return setmetatable({ _NAME = "vicious.widgets" }, { __index = wrequire })
+return setmetatable({ _NAME = (...):match(".*vicious") .. ".widgets" }, { __index = wrequire })

--- a/widgets/mbox_all.lua
+++ b/widgets/mbox_all.lua
@@ -21,7 +21,7 @@
 -- {{{ Grab environment
 local type = type
 local io = { open = io.open }
-local helpers = require("vicious.helpers")
+local helpers = require((...):match(".*vicious") .. ".helpers")
 -- }}}
 
 -- Initialize variables

--- a/widgets/mboxc_all.lua
+++ b/widgets/mboxc_all.lua
@@ -19,7 +19,7 @@
 
 -- {{{ Grab environment
 local io = { open = io.open }
-local helpers = require"vicious.helpers"
+local helpers = require(...):match(".*vicious") .. ".helpers"
 -- }}}
 
 -- {{{ Mbox count widget type

--- a/widgets/mdir_all.lua
+++ b/widgets/mdir_all.lua
@@ -22,8 +22,8 @@
 -- {{{ Grab environment
 local type = type
 
-local helpers = require"vicious.helpers"
-local spawn = require"vicious.spawn"
+local helpers = require(...):match(".*vicious") .. ".helpers"
+local spawn = require(...):match(".*vicious") .. ".spawn"
 -- }}}
 
 -- vicious.widgets.mdir

--- a/widgets/mem_freebsd.lua
+++ b/widgets/mem_freebsd.lua
@@ -27,8 +27,8 @@ local string = {
     find = string.find
 }
 
-local helpers = require("vicious.helpers")
-local spawn = require("vicious.spawn")
+local helpers = require((...):match(".*vicious") .. ".helpers")
+local spawn = require((...):match(".*vicious") .. ".spawn")
 -- }}}
 
 -- Mem: provides RAM and Swap usage statistics

--- a/widgets/mem_linux.lua
+++ b/widgets/mem_linux.lua
@@ -23,7 +23,7 @@
 local io = { lines = io.lines }
 local math = { floor = math.floor }
 local string = { gmatch = string.gmatch }
-local helpers = require"vicious.helpers"
+local helpers = require(...):match(".*vicious") .. ".helpers"
 -- }}}
 
 -- {{{ Memory widget type

--- a/widgets/mpd_all.lua
+++ b/widgets/mpd_all.lua
@@ -27,8 +27,8 @@ local tonumber = tonumber
 local math = { floor = math.floor }
 local type = type
 
-local helpers = require"vicious.helpers"
-local spawn = require"vicious.spawn"
+local helpers = require(...):match(".*vicious") .. ".helpers"
+local spawn = require(...):match(".*vicious") .. ".spawn"
 -- }}}
 
 -- Mpd: provides Music Player Daemon information

--- a/widgets/net_freebsd.lua
+++ b/widgets/net_freebsd.lua
@@ -25,8 +25,8 @@ local string = {
     gmatch = string.gmatch
 }
 
-local helpers = require("vicious.helpers")
-local spawn = require("vicious.spawn")
+local helpers = require((...):match(".*vicious") .. ".helpers")
+local spawn = require((...):match(".*vicious") .. ".spawn")
 -- }}}
 
 

--- a/widgets/net_linux.lua
+++ b/widgets/net_linux.lua
@@ -23,7 +23,7 @@ local tonumber = tonumber
 local os = { time = os.time }
 local io = { lines = io.lines }
 local string = { match = string.match }
-local helpers = require("vicious.helpers")
+local helpers = require((...):match(".*vicious") .. ".helpers")
 -- }}}
 
 -- Initialize function tables

--- a/widgets/notmuch_all.lua
+++ b/widgets/notmuch_all.lua
@@ -17,8 +17,8 @@
 -- along with Vicious.  If not, see <https://www.gnu.org/licenses/>.
 
 local tonumber = tonumber
-local helpers = require("vicious.helpers")
-local spawn = require("vicious.spawn")
+local helpers = require((...):match(".*vicious") .. ".helpers")
+local spawn = require((...):match(".*vicious") .. ".spawn")
 
 
 local notmuch = {}

--- a/widgets/org_all.lua
+++ b/widgets/org_all.lua
@@ -21,7 +21,7 @@
 -- {{{ Grab environment
 local io = { lines = io.lines }
 local os = { time = os.time, date = os.date }
-local helpers = require"vicious.helpers"
+local helpers = require(...):match(".*vicious") .. ".helpers"
 -- }}}
 
 -- {{{ OrgMode widget type

--- a/widgets/os_bsd.lua
+++ b/widgets/os_bsd.lua
@@ -19,8 +19,8 @@
 -- {{{ Grab environment
 local los = { getenv = os.getenv }
 local string = { match = string.match }
-local helpers = require("vicious.helpers")
-local spawn = require("vicious.spawn")
+local helpers = require((...):match(".*vicious") .. ".helpers")
+local spawn = require((...):match(".*vicious") .. ".spawn")
 -- }}}
 
 -- OS: provides operating system information

--- a/widgets/os_linux.lua
+++ b/widgets/os_linux.lua
@@ -25,7 +25,7 @@ local math = { ceil = math.ceil }
 local los = { getenv = os.getenv }
 local string = { gsub = string.gsub }
 
-local helpers = require"vicious.helpers"
+local helpers = require(...):match(".*vicious") .. ".helpers"
 -- }}}
 
 -- {{{ Operating system widget type

--- a/widgets/pkg_all.lua
+++ b/widgets/pkg_all.lua
@@ -22,8 +22,8 @@
 -- along with Vicious.  If not, see <https://www.gnu.org/licenses/>.
 
 -- {{{ Grab environment
-local spawn = require("vicious.spawn")
-local helpers = require("vicious.helpers")
+local spawn = require((...):match(".*vicious") .. ".spawn")
+local helpers = require((...):match(".*vicious") .. ".helpers")
 -- }}}
 
 -- Pkg: provides number of pending updates on UNIX systems

--- a/widgets/raid_linux.lua
+++ b/widgets/raid_linux.lua
@@ -26,7 +26,7 @@ local string = {
     gmatch = string.gmatch
 }
 
-local helpers = require"vicious.helpers"
+local helpers = require(...):match(".*vicious") .. ".helpers"
 -- }}}
 
 -- Initialize function tables

--- a/widgets/thermal_freebsd.lua
+++ b/widgets/thermal_freebsd.lua
@@ -21,7 +21,7 @@
 local string = { match = string.match }
 local type = type
 
-local helpers = require("vicious.helpers")
+local helpers = require((...):match(".*vicious") .. ".helpers")
 -- }}}
 
 -- Thermal: provides temperature levels of ACPI and coretemp thermal zones

--- a/widgets/thermal_linux.lua
+++ b/widgets/thermal_linux.lua
@@ -22,7 +22,7 @@ local type = type
 local tonumber = tonumber
 local string = { match = string.match }
 local math = { floor = math.floor }
-local helpers = require("vicious.helpers")
+local helpers = require((...):match(".*vicious") .. ".helpers")
 -- }}}
 
 -- {{{ Thermal widget type

--- a/widgets/uptime_freebsd.lua
+++ b/widgets/uptime_freebsd.lua
@@ -22,7 +22,7 @@ local tonumber = tonumber
 local math = { floor = math.floor }
 local os = { time = os.time }
 
-local helpers = require("vicious.helpers")
+local helpers = require((...):match(".*vicious") .. ".helpers")
 -- }}}
 
 -- Uptime: provides system uptime and load information

--- a/widgets/uptime_linux.lua
+++ b/widgets/uptime_linux.lua
@@ -21,7 +21,7 @@
 -- {{{ Grab environment
 local math = { floor = math.floor }
 local string = { match = string.match }
-local helpers = require("vicious.helpers")
+local helpers = require((...):match(".*vicious") .. ".helpers")
 -- }}}
 
 -- {{{ Uptime widget type

--- a/widgets/volume_freebsd.lua
+++ b/widgets/volume_freebsd.lua
@@ -20,8 +20,8 @@
 -- {{{ Grab environment
 local tonumber = tonumber
 local string = { match = string.match }
-local helpers = require("vicious.helpers")
-local spawn = require("vicious.spawn")
+local helpers = require((...):match(".*vicious") .. ".helpers")
+local spawn = require((...):match(".*vicious") .. ".spawn")
 -- }}}
 
 -- Volume: provides volume levels and state of requested mixer

--- a/widgets/volume_linux.lua
+++ b/widgets/volume_linux.lua
@@ -25,8 +25,8 @@ local tonumber = tonumber
 local string = { match = string.match }
 local table  = { concat = table.concat }
 
-local helpers = require("vicious.helpers")
-local spawn = require("vicious.spawn")
+local helpers = require((...):match(".*vicious") .. ".helpers")
+local spawn = require((...):match(".*vicious") .. ".spawn")
 -- }}}
 
 -- Volume: provides volume levels and state of requested ALSA mixers

--- a/widgets/weather_all.lua
+++ b/widgets/weather_all.lua
@@ -25,8 +25,8 @@ local math = { ceil = math.ceil }
 local os = { date = os.date, difftime = os.difftime, time = os.time }
 local string = { format = string.format }
 
-local spawn = require"vicious.spawn"
-local helpers = require"vicious.helpers"
+local spawn = require(...):match(".*vicious") .. ".spawn"
+local helpers = require(...):match(".*vicious") .. ".helpers"
 -- }}}
 
 -- Weather: provides weather information for a requested station

--- a/widgets/wifi_linux.lua
+++ b/widgets/wifi_linux.lua
@@ -23,8 +23,8 @@ local type = type
 local tonumber = tonumber
 local math = { floor = math.floor }
 
-local helpers = require"vicious.helpers"
-local spawn = require"vicious.spawn"
+local helpers = require(...):match(".*vicious") .. ".helpers"
+local spawn = require(...):match(".*vicious") .. ".spawn"
 -- }}}
 
 -- Wifi: provides wireless information for a requested interface using iwconfig

--- a/widgets/wifiiw_linux.lua
+++ b/widgets/wifiiw_linux.lua
@@ -23,8 +23,8 @@
 local type = type
 local tonumber = tonumber
 
-local helpers = require("vicious.helpers")
-local spawn = require("vicious.spawn")
+local helpers = require((...):match(".*vicious") .. ".helpers")
+local spawn = require((...):match(".*vicious") .. ".spawn")
 -- }}}
 
 -- Wifiiw: provides wireless information for a requested interface


### PR DESCRIPTION
I changed the require statements to be relative rather than absolute to the config root. This allows for vicious to be put in a folder such as `modules` and accessed with `require("modules.vicious")` without it breaking.  I'm not sure about versioning and such so... I'll leave it up to Y'all. If you want an example of the changes I made in action under AwesomeWM take a look at [Bling](https://github.com/blingcorp/bling) and how their require statements are formatted.