### PR TITLE
[widgets.mpd] Add fields `${Artists}` and `${Genres}`

### DIFF
--- a/docs/source/widgets.rst
+++ b/docs/source/widgets.rst
@@ -290,7 +290,8 @@ Provides Music Player Daemon information.
 
 Supported platforms: platform independent (required tools: ``curl``).
 
-* Argument: an array including password, hostname, port and separator in that order, or a table with the previously mentioned fields.
+* Argument: an array including password, hostname, port and separator in that
+  order, or a table with the previously mentioned fields.
   ``nil`` fields will be fallen back to default
   (``localhost:6600`` without password and ``", "`` as a separator).
 * Returns a table with string keys: ``${volume}``, ``${bitrate}``,
@@ -298,8 +299,8 @@ Supported platforms: platform independent (required tools: ``curl``).
   ``${Elapsed}`` (formatted as [hh:]mm:ss),
   ``${Duration}`` (formatted as [hh:]mm:ss), ``${Progress}`` (in percentage),
   ``${random}``, ``${repeat}``, ``${state}``, ``${Artist}``, ``${Title}``,
-  ``${Artists}`` (All artists concatenated with the configured separator),
-  ``${Generes}`` (All generes concatenated with the configured separator),
+  ``${Artists}`` (all artists concatenated with the configured separator),
+  ``${Genres}`` (all genres concatenated with the configured separator),
   ``${Album}``, ``${Genre}`` and optionally ``${Name}`` and ``${file}``.
 
 In addition, some common mpd commands are available as functions:

--- a/docs/source/widgets.rst
+++ b/docs/source/widgets.rst
@@ -290,14 +290,16 @@ Provides Music Player Daemon information.
 
 Supported platforms: platform independent (required tools: ``curl``).
 
-* Argument: an array including password, hostname and port in that order.
+* Argument: an array including password, hostname, port and separator in that order, or a table with the previously mentioned fields.
   ``nil`` fields will be fallen back to default
-  (``localhost:6600`` without password).
+  (``localhost:6600`` without password and ``", "`` as a separator).
 * Returns a table with string keys: ``${volume}``, ``${bitrate}``,
   ``${elapsed}`` (in seconds), ``${duration}`` (in seconds),
   ``${Elapsed}`` (formatted as [hh:]mm:ss),
   ``${Duration}`` (formatted as [hh:]mm:ss), ``${Progress}`` (in percentage),
   ``${random}``, ``${repeat}``, ``${state}``, ``${Artist}``, ``${Title}``,
+  ``${Artists}`` (All artists concatenated with the configured separator),
+  ``${Generes}`` (All generes concatenated with the configured separator),
   ``${Album}``, ``${Genre}`` and optionally ``${Name}`` and ``${file}``.
 
 In addition, some common mpd commands are available as functions:

--- a/widgets/mpd_all.lua
+++ b/widgets/mpd_all.lua
@@ -125,11 +125,16 @@ function mpd_all.async(format, warg, callback)
         ["{Title}"]    = "N/A",
         ["{Album}"]    = "N/A",
         ["{Genre}"]    = "N/A",
-        --["{Name}"]   = "N/A",
-        --["{file}"]   = "N/A",
+        ["{Artists}"]   = "N/A",
     }
 
+    local separator = warg and (warg.separator or warg[4]) or ", "
+
     local cmd = build_cmd(warg, "status\ncurrentsong\n")
+
+    local function append_with_separator (current, value)
+        return ("%s%s%s"):format(current, separator, value)
+    end
 
     -- Get data from MPD server
     spawn.with_line_callback_with_shell(cmd, {
@@ -144,8 +149,23 @@ function mpd_all.async(format, warg, callback)
                 elseif k == "state" then
                     mpd_state[key] = helpers.capitalize(v)
                 elseif k == "Artist" or k == "Title" or
-                       --k == "Name" or k == "file" or
                        k == "Album" or k == "Genre" then
+                    if k == "Artist" then
+                        local current_artists = mpd_state["{Artists}"]
+                        if current_artists == "N/A" then
+                            mpd_state["{Artists}"] = v
+                        else
+                            mpd_state["{Artists}"] = append_with_separator(current_artists, v)
+                        end
+                    end
+                    if k == "Genre" then
+                        local current_generes = mpd_state["{Generes}"]
+                        if current_generes == "N/A" then
+                            mpd_state["{Generes}"] = v
+                        else
+                            mpd_state["{Generes}"] = append_with_separator(current_generes, v)
+                        end
+                    end
                     mpd_state[key] = v
                 end
             end

--- a/widgets/mpd_all.lua
+++ b/widgets/mpd_all.lua
@@ -123,11 +123,11 @@ function mpd_all.async(format, warg, callback)
         ["{random}"]   = 0,
         ["{state}"]    = "N/A",
         ["{Artist}"]   = "N/A",
-        ["{Artists}"]   = "N/A",
+        ["{Artists}"]  = "N/A",
         ["{Title}"]    = "N/A",
         ["{Album}"]    = "N/A",
         ["{Genre}"]    = "N/A",
-        ["{Genres}"]    = "N/A",
+        ["{Genres}"]   = "N/A",
     }
 
     local separator = warg and (warg.separator or warg[4]) or ", "
@@ -152,22 +152,14 @@ function mpd_all.async(format, warg, callback)
                     mpd_state[key] = helpers.capitalize(v)
                 elseif k == "Artist" or k == "Title" or
                        k == "Album" or k == "Genre" then
-                    if k == "Artist" then
-                        local current_artists = mpd_state["{Artists}"]
-                        if current_artists == "N/A" then
-                            mpd_state["{Artists}"] = v
+                    if k == "Artist" or k == "Genre" then
+                        local current_key = "{" .. k .. "s}"
+                        local current_state = mpd_state[current_key]
+                        if current_state == "N/A" then
+                            mpd_state[current_key] = v
                         else
-                            mpd_state["{Artists}"] = append_with_separator(
-                                current_artists, v)
-                        end
-                    end
-                    if k == "Genre" then
-                        local current_generes = mpd_state["{Generes}"]
-                        if current_generes == "N/A" then
-                            mpd_state["{Generes}"] = v
-                        else
-                            mpd_state["{Generes}"] = append_with_separator(
-                                current_generes, v)
+                            mpd_state[current_key] = append_with_separator(
+                                current_state, v)
                         end
                     end
                     mpd_state[key] = v

--- a/widgets/mpd_all.lua
+++ b/widgets/mpd_all.lua
@@ -156,7 +156,8 @@ function mpd_all.async(format, warg, callback)
                         if current_artists == "N/A" then
                             mpd_state["{Artists}"] = v
                         else
-                            mpd_state["{Artists}"] = append_with_separator(current_artists, v)
+                            mpd_state["{Artists}"] = append_with_separator(
+                                current_artists, v)
                         end
                     end
                     if k == "Genre" then
@@ -164,7 +165,8 @@ function mpd_all.async(format, warg, callback)
                         if current_generes == "N/A" then
                             mpd_state["{Generes}"] = v
                         else
-                            mpd_state["{Generes}"] = append_with_separator(current_generes, v)
+                            mpd_state["{Generes}"] = append_with_separator(
+                                current_generes, v)
                         end
                     end
                     mpd_state[key] = v

--- a/widgets/mpd_all.lua
+++ b/widgets/mpd_all.lua
@@ -6,6 +6,7 @@
 -- Copyright (C) 2019  Juan Carlos Menonita <JuanKman94@users.noreply.github.com>
 -- Copyright (C) 2019  Lorenzo Gaggini <lg@lgaggini.net>
 -- Copyright (C) 2022  Constantin Piber <cp.piber@gmail.com>
+-- Copyright (C) 2023  Cássio Ávila <cassioavila@autistici.org>
 --
 -- This file is part of Vicious.
 --

--- a/widgets/mpd_all.lua
+++ b/widgets/mpd_all.lua
@@ -122,10 +122,11 @@ function mpd_all.async(format, warg, callback)
         ["{random}"]   = 0,
         ["{state}"]    = "N/A",
         ["{Artist}"]   = "N/A",
+        ["{Artists}"]   = "N/A",
         ["{Title}"]    = "N/A",
         ["{Album}"]    = "N/A",
         ["{Genre}"]    = "N/A",
-        ["{Artists}"]   = "N/A",
+        ["{Genres}"]    = "N/A",
     }
 
     local separator = warg and (warg.separator or warg[4]) or ", "


### PR DESCRIPTION
Resolves GH-116 

Adds new return values to widgets.mpd that concatenate all artists and generes when there's more than one. For tracks with vorbis metadata.

I've also updated the docs to reflect those changes.