### PR TITLE
docs: Update usage of batwidget with updated api for wibox margin examples.rst

### DIFF
--- a/docs/source/examples.rst
+++ b/docs/source/examples.rst
@@ -63,7 +63,7 @@ and displays a progressbar, provides ``BAT0`` as battery ID:
    batwidget = wibox.widget.progressbar()
 
    -- Create wibox with batwidget
-   batbox = wibox.layout.margin(
+   batbox = wibox.container.margin(
        wibox.widget{ { max_value = 1, widget = batwidget,
                        border_width = 0.5, border_color = "#000000",
                        color = { type = "linear",


### PR DESCRIPTION
I'm new to awesomewm configuration and it was a problem to understand why battery example widget is not shown on the top bar, after I added the example as is to my config, because awesomewm don't provide any errors when loading config with previous version of example.

but they changed the api for `wibox.layout.margin`, now it is `wibox.container.margin`([link](https://awesomewm.org/doc/api/classes/wibox.container.margin.html))

after changing it in my config, I got this widget on my top bar.