### PR TITLE
[bat_linux] Fallback to computing bat (dis)charge rate in some cases

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+Changes in 2.7.1
+----------------
+
+Fixed:
+
+- [bat_linux] Fallback to computing bat (dis)charge rate in some cases
+
 Changes in 2.7.0
 ----------------
 

--- a/widgets/bat_linux.lua
+++ b/widgets/bat_linux.lua
@@ -4,6 +4,7 @@
 -- Copyright (C) 2017  David Udelson <dru5@cornell.edu>
 -- Copyright (C) 2017  Roberto <empijei@users.noreply.github.com>
 -- Copyright (C) 2017  mutlusun <mutlusun@github.com>
+-- Copyright (C) 2024  arch-stack <arch-stack@github.com>
 --
 -- This file is part of Vicious.
 --
@@ -46,8 +47,13 @@ return helpers.setcall(function (format, warg)
 
     -- Get current power usage in watt
     local curpower = "N/A"
+
     if battery.power_now then
         curpower = string.format("%.2f", tonumber(battery.power_now) /1000000)
+    elseif battery.current_now and battery.voltage_now then
+        local current = tonumber(battery.current_now)
+        local voltage = tonumber(battery.voltage_now)
+        curpower = string.format("%.2f", current * voltage / 10^12)
     end
 
     -- Check if the battery is present


### PR DESCRIPTION
This PR is to fix the issue in #119 

Some devices/batteries do not provide the `/sys/class/power_supply/BAT#/power_now` file but they do provide the `/sys/class/power_supply/BAT#/current_now` and `/sys/class/power_supply/BAT#/voltage_now` files

Using the basic P=EI formula (or P=VI if you prefer) to compute power we can take the voltage and current values and multiply them to get the same kind of power value instead of always showing N/A